### PR TITLE
Update pure-pynbo submodule url, for non-ssh users

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "pure-pynbo"]
 	path = pure-pynbo
-	url = git@github.com:Python-Nairobi/pure-pynbo.git
+	url = https://github.com/Python-Nairobi/pure-pynbo.git
 [submodule "pelican-plugins"]
 	path = pelican-plugins
 	url = https://github.com/Python-Nairobi/pelican-plugins.git


### PR DESCRIPTION
This is for an upcoming PR I'm writing, to add this blog to a docker image.

During test-building, I get this error, which is because the docker user doesn't have a ssh key logged into the server:

```
Cloning into 'pure-pynbo'...                                                                                                                           
Host key verification failed.                                                                                                                          
fatal: Could not read from remote repository.                                                                                                          
                                                                                                                                                       
Please make sure you have the correct access rights                                                                                                    
and the repository exists.
Clone of 'git@github.com:Python-Nairobi/pure-pynbo.git' into submodule path 'pure-pynbo' failed
The command '/bin/sh -c git submodule update --init --recursive' returned a non-zero code: 1
```


An alternative would be to assign a deploy SSH key to that user in the image.